### PR TITLE
feat(PE-7174): support for primary name protocol with io process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Calls the IO Network Process to release the specified ArNS name that is registered to the ANT.
 - Reassign-Name Handler
   - Calls the IO Network Process to assign a new ANT Process to the respective name - must be a name registered the the ANT in question.
-- Set-Decription Handler
+- Set-Description Handler
   - Allows for setting the description of the ANT
 - Set-Keywords Handler
   - Allows for setting keywords on the ANT
 - Set-Logo Handler
   - Allows for setting the logo of the ANT
+- Add Approve-Primary-Name handler
+  - Approves a primary name request on the specified IO process ID
+- Add Remove-Primary-Names handler
+  - Forwards a Remove-Primary-Names action to the specified IO process ID
 
 ### Changed
 

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -80,7 +80,7 @@ function ant.init()
 		ReassignName = "Reassign-Name",
 		CreateClaim = "Create-Primary-Name-Claims",
 		RevokeClaims = "Revoke-Primary-Name-Claims",
-		RemovePrimaryNames = "Remove-Primary-Name-Claims",
+		RemovePrimaryNames = "Remove-Primary-Names",
 	}
 
 	local TokenSpecActionMap = {

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -272,7 +272,7 @@ function ant.init()
 			["Process-Id"] = antProcessIdToReassign,
 		})
 	end)
-  
+
 	createActionHandler(ActionMap.ApproveName, function(msg)
 		--- NOTE: this could be modified to allow specific users/controllers to create claims
 		utils.validateOwner(msg.From)

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -78,9 +78,8 @@ function ant.init()
 		-- IO Network Contract Handlers
 		ReleaseName = "Release-Name",
 		ReassignName = "Reassign-Name",
-		CreateClaim = "Create-Primary-Name-Claims",
-		RevokeClaims = "Revoke-Primary-Name-Claims",
-		RemovePrimaryNames = "Remove-Primary-Names",
+		ApproveName = "Approve-Primary-Name",
+		RemoveNames = "Remove-Primary-Names",
 	}
 
 	local TokenSpecActionMap = {
@@ -279,10 +278,10 @@ function ant.init()
 		})
 	end)
 
-	createActionHandler(ActionMap.CreateClaim, function(msg)
+	createActionHandler(ActionMap.ApproveName, function(msg)
 		--- NOTE: this could be modified to allow specific users/controllers to create claims
 		utils.validateOwner(msg.From)
-		utils.validateArweaveId(msg.Tags["Process-Id"])
+		utils.validateArweaveId(msg.Tags["IO-Process-Id"])
 		utils.validateArweaveId(msg.Tags.Recipient)
 
 		assert(msg.Tags.Name, "Name is required")
@@ -293,49 +292,16 @@ function ant.init()
 
 		ao.send({
 			Target = ioProcess,
-			Action = "Create-Primary-Name-Claim",
-			Name = name,
-			Recipient = recipient,
-		})
-
-		ao.send({
-			Target = msg.From,
-			Action = "Create-Primary-Name-Claim-Notice",
+			Action = "Approve-Primary-Name-Request",
 			Name = name,
 			Recipient = recipient,
 		})
 	end)
 
-	createActionHandler(ActionMap.RevokeClaims, function(msg)
-		--- NOTE: this could be modified to allow specific users/controllers to revoke claims
-		utils.validateOwner(msg.From)
-		utils.validateArweaveId(msg.Tags["Process-Id"])
-
-		assert(msg.Tags.Names, "Names are required")
-
-		local ioProcess = msg.Tags["IO-Process-Id"]
-		local names = utils.splitString(msg.Tags.Names)
-		for _, name in ipairs(names) do
-			utils.validateUndername(name)
-		end
-
-		ao.send({
-			Target = ioProcess,
-			Action = "Revoke-Primary-Name-Claims",
-			Names = json.encode(names),
-		})
-
-		ao.send({
-			Target = msg.From,
-			Action = "Revoke-Primary-Name-Claims-Notice",
-			Names = json.encode(names),
-		})
-	end)
-
-	createActionHandler(ActionMap.RemovePrimaryNames, function(msg)
+	createActionHandler(ActionMap.RemoveNames, function(msg)
 		--- NOTE: this could be modified to allow specific users/controllers to remove primary names
 		utils.validateOwner(msg.From)
-		utils.validateArweaveId(msg.Tags["Process-Id"])
+		utils.validateArweaveId(msg.Tags["IO-Process-Id"])
 
 		assert(msg.Tags.Names, "Names are required")
 
@@ -348,12 +314,6 @@ function ant.init()
 		ao.send({
 			Target = ioProcess,
 			Action = "Remove-Primary-Names",
-			Names = json.encode(names),
-		})
-
-		ao.send({
-			Target = msg.From,
-			Action = "Remove-Primary-Names-Notice",
 			Names = json.encode(names),
 		})
 	end)

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -314,7 +314,7 @@ function ant.init()
 		assert(msg.Tags.Names, "Names are required")
 
 		local ioProcess = msg.Tags["IO-Process-Id"]
-		local names = utils.split(msg.Tags.Names, ",")
+		local names = utils.splitString(msg.Tags.Names)
 		for _, name in ipairs(names) do
 			utils.validateUndername(name)
 		end
@@ -340,7 +340,7 @@ function ant.init()
 		assert(msg.Tags.Names, "Names are required")
 
 		local ioProcess = msg.Tags["IO-Process-Id"]
-		local names = utils.split(msg.Tags.Names, ",")
+		local names = utils.splitString(msg.Tags.Names)
 		for _, name in ipairs(names) do
 			utils.validateUndername(name)
 		end

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -280,6 +280,7 @@ function ant.init()
 	end)
 
 	createActionHandler(ActionMap.CreateClaim, function(msg)
+		--- NOTE: this could be modified to allow specific users/controllers to create claims
 		utils.validateOwner(msg.From)
 		utils.validateArweaveId(msg.Tags["Process-Id"])
 		utils.validateArweaveId(msg.Tags.Recipient)
@@ -290,7 +291,6 @@ function ant.init()
 		local recipient = msg.Tags.Recipient
 		local ioProcess = msg.Tags["IO-Process-Id"]
 
-		-- send the release message to the provided IO Process Id
 		ao.send({
 			Target = ioProcess,
 			Action = "Create-Primary-Name-Claim",
@@ -307,6 +307,7 @@ function ant.init()
 	end)
 
 	createActionHandler(ActionMap.RevokeClaims, function(msg)
+		--- NOTE: this could be modified to allow specific users/controllers to revoke claims
 		utils.validateOwner(msg.From)
 		utils.validateArweaveId(msg.Tags["Process-Id"])
 
@@ -318,7 +319,6 @@ function ant.init()
 			utils.validateUndername(name)
 		end
 
-		-- send the release message to the provided IO Process Id
 		ao.send({
 			Target = ioProcess,
 			Action = "Revoke-Primary-Name-Claims",
@@ -333,6 +333,7 @@ function ant.init()
 	end)
 
 	createActionHandler(ActionMap.RemovePrimaryNames, function(msg)
+		--- NOTE: this could be modified to allow specific users/controllers to remove primary names
 		utils.validateOwner(msg.From)
 		utils.validateArweaveId(msg.Tags["Process-Id"])
 
@@ -344,7 +345,6 @@ function ant.init()
 			utils.validateUndername(name)
 		end
 
-		-- send the release message to the provided IO Process Id
 		ao.send({
 			Target = ioProcess,
 			Action = "Remove-Primary-Names",

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -41,14 +41,18 @@ function utils.deepCopy(original)
 	return copy
 end
 
---- @param str string
---- @param delimiter string
---- @description Splits a string by the delimiter
---- @return string[]
-function utils.split(str, delimiter)
-	return { string.match(str, "([^" .. delimiter .. "]+)") }
+--- Splits a string by a delimiter
+--- @param input string The string to split
+--- @param delimiter string|nil The delimiter to split by, defaults to ","
+--- @return table The split string
+function utils.splitString(input, delimiter)
+	delimiter = delimiter or ","
+	local result = {}
+	for token in (input or ""):gmatch(string.format("([^%s]+)", delimiter)) do
+		table.insert(result, token)
+	end
+	return result
 end
-
 -- NOTE: lua 5.3 has limited regex support, particularly for lookaheads and negative lookaheads or use of {n}
 ---@param name string
 ---@description Asserts that the provided name is a valid undername

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -41,6 +41,14 @@ function utils.deepCopy(original)
 	return copy
 end
 
+--- @param str string
+--- @param delimiter string
+--- @description Splits a string by the delimiter
+--- @return string[]
+function utils.split(str, delimiter)
+	return { string.match(str, "([^" .. delimiter .. "]+)") }
+end
+
 -- NOTE: lua 5.3 has limited regex support, particularly for lookaheads and negative lookaheads or use of {n}
 ---@param name string
 ---@description Asserts that the provided name is a valid undername

--- a/test/info.test.mjs
+++ b/test/info.test.mjs
@@ -61,6 +61,9 @@ describe('aos Info', async () => {
       'state',
       'releaseName',
       'reassignName',
+      'createPrimaryNameClaims',
+      'revokePrimaryNameClaims',
+      'removePrimaryNames',
     ]);
   });
 

--- a/test/info.test.mjs
+++ b/test/info.test.mjs
@@ -61,8 +61,7 @@ describe('aos Info', async () => {
       'state',
       'releaseName',
       'reassignName',
-      'createPrimaryNameClaims',
-      'revokePrimaryNameClaims',
+      'approvePrimaryName',
       'removePrimaryNames',
     ]);
   });

--- a/test/io.test.mjs
+++ b/test/io.test.mjs
@@ -115,14 +115,13 @@ describe('IO Network Updates', async () => {
     );
     assert(ioProcessMessage, 'Message to IO Process not found');
 
-    // Check if there is a message to the sender with Action 'Reassign-Name-Submit-Notice'
+    // Check if there is a message to the sender with Action 'Reassign-Name-Notice'
     const senderMessage = result.Messages.find(
       (msg) =>
         msg.Target === STUB_ADDRESS &&
         msg.Tags.some(
           (tag) =>
-            tag.name === 'Action' &&
-            tag.value === 'Reassign-Name-Submit-Notice',
+            tag.name === 'Action' && tag.value === 'Reassign-Name-Notice',
         ) &&
         msg.Tags.some(
           (tag) => tag.name === 'Initiator' && tag.value === STUB_ADDRESS,

--- a/test/primary_names.test.mjs
+++ b/test/primary_names.test.mjs
@@ -1,0 +1,106 @@
+import { createAntAosLoader } from './utils.mjs';
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  AO_LOADER_HANDLER_ENV,
+  DEFAULT_HANDLE_OPTIONS,
+  STUB_ADDRESS,
+} from '../tools/constants.mjs';
+
+describe('Primary Names', async () => {
+  const { handle: originalHandle, memory: startMemory } =
+    await createAntAosLoader();
+
+  async function handle(options = {}, mem = startMemory) {
+    return originalHandle(
+      mem,
+      {
+        ...DEFAULT_HANDLE_OPTIONS,
+        ...options,
+      },
+      AO_LOADER_HANDLER_ENV,
+    );
+  }
+
+  it('should send approval for name request', async () => {
+    const res = await handle({
+      Tags: [
+        {
+          name: 'Action',
+          value: 'Approve-Primary-Name',
+        },
+        { name: 'IO-Process-Id', value: ''.padEnd(43, '1') },
+        { name: 'Recipient', value: ''.padEnd(43, '2') },
+        { name: 'Name', value: ''.padEnd(43, '3') },
+      ],
+    });
+
+    const approveNameRequest = res.Messages[0];
+    const actionTag = approveNameRequest.Tags.find((t) => t.name == 'Action');
+    const recipientTag = approveNameRequest.Tags.find(
+      (t) => t.name == 'Recipient',
+    );
+    const nameTag = approveNameRequest.Tags.find((t) => t.name == 'Name');
+
+    assert.strictEqual(approveNameRequest.Target, ''.padEnd(43, '1'));
+    assert.strictEqual(actionTag.value, 'Approve-Primary-Name-Request');
+    assert.strictEqual(recipientTag.value, ''.padEnd(43, '2'));
+    assert.strictEqual(nameTag.value, ''.padEnd(43, '3'));
+  });
+
+  it('should not approve request if caller not owner', async () => {
+    const res = await handle({
+      Owner: 'not-owner'.padEnd(43, '1'),
+      From: 'not-owner'.padEnd(43, '1'),
+      Tags: [
+        {
+          name: 'Action',
+          value: 'Approve-Primary-Name',
+        },
+        { name: 'IO-Process-Id', value: ''.padEnd(43, '1') },
+        { name: 'Recipient', value: ''.padEnd(43, '2') },
+        { name: 'Name', value: ''.padEnd(43, '3') },
+      ],
+    });
+    const invalidMessage = res.Messages[0];
+    const actionTag = invalidMessage.Tags.find((t) => t.name == 'Action');
+    assert.strictEqual(actionTag.value, 'Invalid-Approve-Primary-Name-Notice');
+  });
+
+  it('should send remove names request', async () => {
+    const names = ['foo', 'bar', 'baz'];
+    const res = await handle({
+      Tags: [
+        { name: 'Action', value: 'Remove-Primary-Names' },
+        { name: 'Names', value: names.join(',') },
+        { name: 'IO-Process-Id', value: ''.padEnd(43, '2') },
+      ],
+    });
+
+    const removePrimaryNamesMsg = res.Messages[0];
+    const actionTag = removePrimaryNamesMsg.Tags.find(
+      (t) => t.name == 'Action',
+    );
+    const namesTag = removePrimaryNamesMsg.Tags.find((t) => t.name == 'Names');
+
+    assert.strictEqual(removePrimaryNamesMsg.Target, ''.padEnd(43, '2'));
+    assert.strictEqual(actionTag.value, 'Remove-Primary-Names');
+    assert.strictEqual(namesTag.value, JSON.stringify(names));
+  });
+  it('should not send remove names request if caller not owner', async () => {
+    const names = ['foo', 'bar', 'baz'];
+    const res = await handle({
+      Owner: 'not-owner'.padEnd(43, '1'),
+      From: 'not-owner'.padEnd(43, '1'),
+      Tags: [
+        { name: 'Action', value: 'Remove-Primary-Names' },
+        { name: 'Names', value: names.join(',') },
+        { name: 'IO-Process-Id', value: ''.padEnd(43, '2') },
+      ],
+    });
+
+    const invalidMessage = res.Messages[0];
+    const actionTag = invalidMessage.Tags.find((t) => t.name == 'Action');
+    assert.strictEqual(actionTag.value, 'Invalid-Remove-Primary-Names-Notice');
+  });
+});


### PR DESCRIPTION
These can be extended to allow controllers to create and remove primary name claims.

Related PR: https://github.com/ar-io/ar-io-network-process/pull/175

TODO:
- sending `Remove-Primary-Name` message to IO process when updating a name. Behind a flag like `Cast`?

_any state changes we want to store on an ANT that track primary names to owners they may care about?_