### PR TITLE
feat(PE-7422): add ant boot loader handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,20 @@ This repository provides two flavours of ANT process module, AOS and a custom mo
   - [Testing](#testing)
   - [Building the AOS code](#building-the-aos-code)
     - [Build](#build)
+      - [Lua code](#lua-code)
+      - [Module WASM Binary](#module-wasm-binary)
     - [Publish](#publish)
+      - [Lua code](#lua-code-1)
+      - [Module WASM Binary](#module-wasm-binary-1)
     - [Load](#load)
+      - [Lua code](#lua-code-2)
+      - [Module WASM Binary](#module-wasm-binary-2)
     - [Spawn](#spawn)
+      - [Lua code](#lua-code-3)
+      - [Module WASM Binary](#module-wasm-binary-3)
 - [Handler Methods](#handler-methods)
+  - [Boot Methods](#boot-methods)
+    - [`_boot` (WASM Binary only)](#_boot-wasm-binary-only)
   - [Read Methods](#read-methods)
     - [`Info`](#info)
     - [`Total-Supply`](#total-supply)
@@ -59,10 +69,10 @@ yarn
 ```
 
 Then install the ao cli - read the docs [here](https://github.com/permaweb/ao/tree/main/dev-cli)
-Below is latest version as of writing, refer to the docs for the latest version.
+Refer to the docs for installing different versions.
 
 ```sh
-curl -L https://arweave.net/iVthglhSN7G9LuJSU_h5Wy_lcEa0RE4VQmrtoBMj7Bw | bash
+curl -L https://install_ao.g8way.io | bash
 ```
 
 You may need to follow the instructions in the cli to add the program to your PATH.
@@ -81,39 +91,103 @@ busted .
 
 This bundles the ant-aos code and outputs it to `dist` folder. This can then be used to send to the `Eval` method on AOS to load the ANT source code.
 
+##### Lua code
+
 ```bash
 yarn aos:build
+```
+
+##### Module WASM Binary
+
+```bash
+yarn module:build
 ```
 
 #### Publish
 
 Ensure that in the `tools` directory you place you Arweave JWK as `key.json`
 
+##### Lua code
+
 ```bash
 yarn aos:publish
+```
+
+##### Module WASM Binary
+
+```bash
+yarn module:publish
 ```
 
 #### Load
 
 This will load an AOS module into the loader, followed by the bundled aos Lua file to verify that it is a valid build.
 
+##### Lua code
+
 ```bash
 yarn aos:load
 ```
 
+##### Module WASM Binary
+
+```bash
+yarn module:load
+```
+
 #### Spawn
 
-this will spawn an aos process and load the bundled lua code into it.
+This will spawn an aos process and load the bundled lua code into it.
+
+##### Lua code
 
 ```bash
 yarn aos:spawn
 ```
 
-This will deploy the bundled lua file to arweave as an L1 transaction, so your wallet will need AR to pay the gas.
+##### Module WASM Binary
+
+```bash
+yarn module:spawn
+```
+
+This will deploy the bundled lua file or WASM module to arweave as an L2 ([ANS-104]) transaction, so your wallet will need Turbo Credits to pay the gas.
 
 ## Handler Methods
 
-For interacting with handlers please refer to the [AO Cookbook]
+For interacting with handlers please refer to the [AR.IO SDK] or the [AO Cookbook]
+
+### Boot Methods
+
+#### `_boot` (WASM Binary only)
+
+When compiled as a WASM Module Binary the ANT provides a boot method to initialize the state of the ANT.
+
+This will send a `Credit-Notice` to the initialized Owner (if applicable) and a `State-Notice` to the [ANT Registry].
+
+If a valid JSON string state is provided, it will be used to set the initial state of the ANT.
+
+Example:
+
+```json
+{
+  "name": "Test Process",
+  "ticker": "TEST",
+  "description": "TEST DESCRIPTION",
+  "keywords": ["KEYWORD-1", "KEYWORD-2", "KEYWORD-3"],
+  "owner": "STUB_ADDRESS",
+  "controllers": ["STUB_ADDRESS"],
+  "balances": {
+    "STUB_ADDRESS": 1
+  },
+  "records": {
+    "@": {
+      "transactionId": "3333333333333333333333333333333333333333333",
+      "ttlSeconds": 3600
+    }
+  }
+}
+```
 
 ### Read Methods
 
@@ -412,8 +486,11 @@ dependencies = {
 - [ArNS Docs]
 - [ArNS Portal]
 - [AO Cookbook]
+- [AR.IO SDK]
 
 [AR.IO Gateways]: https://docs.ar.io/gateways/ar-io-node/overview/
+[AR.IO SDK]: https://www.npmjs.com/package/@ar.io/sdk
+[ANT Registry]: https://github.com/ar-io/ar-io-ant-registry-process
 [ArNS Docs]: https://ar.io/docs/arns/
 [ArNS ANT Docs]: https://ar.io/docs/arns/#arweave-name-token-ant
 [ArNS Portal]: https://arns.app

--- a/src/common/initialize.lua
+++ b/src/common/initialize.lua
@@ -2,6 +2,21 @@ local utils = require(".common.utils")
 local json = require(".common.json")
 local initialize = {}
 
+---@alias InitializeANTState {
+--- name: string,
+--- ticker: string,
+--- description: string,
+--- keywords: table<string>,
+--- logo: string,
+--- balances: table<string, integer>,
+--- owner: string,
+--- controllers: string[],
+--- records: table<string, Record>,
+---}
+
+---@description Initializes the ANT state from a JSON string
+---@param state InitializeANTState
+---@return string JSON representation of the initialized ANT State
 function initialize.initializeANTState(state)
 	local encoded = json.decode(state)
 	local balances = encoded.balances

--- a/src/common/initialize.lua
+++ b/src/common/initialize.lua
@@ -2,7 +2,7 @@ local utils = require(".common.utils")
 local json = require(".common.json")
 local initialize = {}
 
----@alias InitializeANTState {
+---@alias InitialANTState {
 --- name: string,
 --- ticker: string,
 --- description: string,
@@ -14,8 +14,8 @@ local initialize = {}
 --- records: table<string, Record>,
 ---}
 
----@description Initializes the ANT state from a JSON string
----@param state InitializeANTState
+--- Initializes the ANT state from a JSON string
+---@param state InitialANTState
 ---@return string JSON representation of the initialized ANT State
 function initialize.initializeANTState(state)
 	local encoded = json.decode(state)

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -352,14 +352,17 @@ function ant.init()
 			end
 		end
 
-		utils.Send(
-			msg,
-			notices.credit({
-				From = msg.From,
-				Sender = Owner,
-				Recipient = Owner,
-			})
-		)
+		if Owner then
+			utils.Send(
+				msg,
+				notices.credit({
+					From = msg.From,
+					Sender = Owner,
+					Recipient = Owner,
+				})
+			)
+		end
+
 		if AntRegistryId then
 			notices.notifyState(msg, AntRegistryId)
 		end

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -330,7 +330,7 @@ function ant.init()
 	This handler OVERRIDES this and replaces it with our ANT state initialization handler.
 
 	]]
-	Handlers.once("_boot", function(msg)
+	Handlers.prepend("_boot", function(msg)
 		return msg.Tags.Type == "Process" and Owner == msg.From
 	end, function(msg)
 		if type(msg.Data) == "string" then
@@ -366,7 +366,7 @@ function ant.init()
 		if AntRegistryId then
 			notices.notifyState(msg, AntRegistryId)
 		end
-	end)
+	end, 1)
 end
 
 return ant

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -315,7 +315,7 @@ function ant.init()
 	end)
 
 	Handlers.prepend("_bootAnt", function(msg)
-		return msg.Tags.Type == "Process" and msg.Tags["ANT-Registry-Id"] and Owner == msg.From
+		return msg.Tags.Type == "Process" and Owner == msg.From
 	end, function(msg)
 		if msg.Data and msg.Tags["Initialize-State"] then
 			local status, res = xpcall(function()

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -325,33 +325,45 @@ function ant.init()
 		})
 	end)
 
-	Handlers.prepend("_bootAnt", function(msg)
+	--[[
+	AOS provides a _boot handler that is designed to load Lua code on boot.
+	This handler OVERRIDES this and replaces it with our ANT state initialization handler.
+
+	]]
+	Handlers.once("_boot", function(msg)
 		return msg.Tags.Type == "Process" and Owner == msg.From
 	end, function(msg)
-		if msg.Data and msg.Tags["Initialize-State"] then
+		if type(msg.Data) == "string" then
+			-- If data is present assume its an attempt to initialize the state
 			local status, res = xpcall(function()
 				initialize.initializeANTState(msg.Data)
 			end, utils.errorHandler)
 			if not status then
-				ao.send(notices.addForwardedTags(msg, {
-					Target = Owner,
-					Error = res or "",
-					Data = res or "",
-					Action = "Invalid-Boot-Ant-Notice",
-					["Message-Id"] = msg.Id,
-				}))
+				utils.Send(
+					msg,
+					notices.addForwardedTags(msg, {
+						Target = Owner,
+						Error = res or "",
+						Data = res or "",
+						Action = "Invalid-Boot-Notice",
+						["Message-Id"] = msg.Id,
+					})
+				)
 			end
 		end
 
-		ao.send(notices.credit({
-			From = ao.id,
-			Sender = Owner,
-			Recipient = Owner,
-		}))
+		utils.Send(
+			msg,
+			notices.credit({
+				From = msg.From,
+				Sender = Owner,
+				Recipient = Owner,
+			})
+		)
 		if AntRegistryId then
 			notices.notifyState(msg, AntRegistryId)
 		end
-	end, 1)
+	end)
 end
 
 return ant

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -330,7 +330,7 @@ function ant.init()
 	This handler OVERRIDES this and replaces it with our ANT state initialization handler.
 
 	]]
-	Handlers.prepend("_boot", function(msg)
+	Handlers.once("_boot", function(msg)
 		return msg.Tags.Type == "Process" and Owner == msg.From
 	end, function(msg)
 		if type(msg.Data) == "string" then
@@ -366,7 +366,7 @@ function ant.init()
 		if AntRegistryId then
 			notices.notifyState(msg, AntRegistryId)
 		end
-	end, 1)
+	end)
 end
 
 return ant

--- a/test/boot.test.mjs
+++ b/test/boot.test.mjs
@@ -1,0 +1,71 @@
+import { createAntAosLoader } from './utils.mjs';
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  AO_LOADER_HANDLER_ENV,
+  DEFAULT_HANDLE_OPTIONS,
+  STUB_ADDRESS,
+  STUB_ANT_REGISTRY_ID,
+} from '../tools/constants.mjs';
+
+describe('aos Info', async () => {
+  const { handle: originalHandle, memory: startMemory } =
+    await createAntAosLoader();
+
+  async function handle(options = {}, mem = startMemory) {
+    return originalHandle(
+      mem,
+      {
+        ...DEFAULT_HANDLE_OPTIONS,
+        ...options,
+      },
+      AO_LOADER_HANDLER_ENV,
+    );
+  }
+
+  it('should get the process info', async () => {
+    const antState = {
+      name: 'Test Process',
+      ticker: 'TEST',
+      description: 'TEST DESCRIPTION',
+      keywords: ['KEYWORD-1', 'KEYWORD-2', 'KEYWORD-3'],
+      owner: STUB_ADDRESS,
+      controllers: [STUB_ADDRESS],
+      balances: { [STUB_ADDRESS]: 1 },
+      records: {
+        '@': {
+          transactionId: ''.padEnd(43, '3'),
+          ttlSeconds: 3600,
+        },
+      },
+    };
+    const result = await handle({
+      Data: JSON.stringify(antState),
+      Tags: [
+        {
+          name: 'Type',
+          value: 'Process',
+        },
+        {
+          name: 'ANT-Registry-Id',
+          value: STUB_ANT_REGISTRY_ID,
+        },
+        {
+          name: 'Initialize-State',
+          value: 'true',
+        },
+      ],
+    });
+
+    const messages = result.Messages;
+    const stateNotice = messages.find((m) => m.Target === STUB_ANT_REGISTRY_ID);
+    const creditNotice = messages.find((m) => m.Target === STUB_ADDRESS);
+
+    assert(stateNotice, 'no state notice found');
+    assert(
+      JSON.parse(stateNotice.Data).Name === antState.name,
+      'state did not initialize correctly',
+    );
+    assert(creditNotice, 'no credit notice found');
+  });
+});

--- a/test/info.test.mjs
+++ b/test/info.test.mjs
@@ -37,6 +37,7 @@ describe('aos Info', async () => {
     assert(processInfo.Owner);
     assert(processInfo.Handlers);
     assert.deepStrictEqual(processInfo.Handlers, [
+      '_bootAnt',
       '_boot',
       '_eval',
       '_default',

--- a/test/info.test.mjs
+++ b/test/info.test.mjs
@@ -37,7 +37,6 @@ describe('aos Info', async () => {
     assert(processInfo.Owner);
     assert(processInfo.Handlers);
     assert.deepStrictEqual(processInfo.Handlers, [
-      '_bootAnt',
       '_boot',
       '_eval',
       '_default',


### PR DESCRIPTION
This adds the _bootAnt handler.

When spawning a process, we can add ANT state into the Data field of the process, along with an Initialize-State flag that will tell the handler to initialize the state with the provided defaults.

We also send a credit notice to the owner of the process (after initializing the state) and a state notice to the ANT registry.

This spawns the ANT, sets up the state, and registers the ANT with one signature.