### PR TITLE
fix(PE-7772): create proposal tool for publishing

### DIFF
--- a/.github/workflows/ant.yaml
+++ b/.github/workflows/ant.yaml
@@ -174,3 +174,11 @@ jobs:
           fields: repo,message,commit,author,action,eventName,ref,workflow,job
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  propose:
+    needs: [publish]
+    if: needs.publish.result == 'success'
+    uses: ./.github/workflows/vaot-proposal.yaml
+    secrets: inherit
+    with:
+      published_module_id: ${{ needs.publish.outputs.published_module_id }}
+      published_lua_code_id: ${{ needs.publish.outputs.published_lua_code_id }}

--- a/.github/workflows/ant.yaml
+++ b/.github/workflows/ant.yaml
@@ -182,3 +182,4 @@ jobs:
     with:
       published_module_id: ${{ needs.publish.outputs.published_module_id }}
       published_lua_code_id: ${{ needs.publish.outputs.published_lua_code_id }}
+      dryrun: ${{ vars.DRYRUN_PROPOSAL }}

--- a/.github/workflows/vaot-proposal.yaml
+++ b/.github/workflows/vaot-proposal.yaml
@@ -13,6 +13,9 @@ on:
       published_lua_code_id:
         required: false
         type: string
+      dryrun:
+        required: false
+        type: boolean
 
 jobs:
   propose:
@@ -33,6 +36,7 @@ jobs:
           VAOT_ID: ${{ vars.VAOT_ID}}
           MODULE_ID: ${{ inputs.published_module_id }}
           LUA_SOURCE_ID: ${{ inputs.published_lua_code_id }}
+          DRY_RUN: ${{ inputs.dryrun }}
       - name: Notify Success
         if: success()
         uses: rtCamp/action-slack-notify@v2.3.0

--- a/.github/workflows/vaot-proposal.yaml
+++ b/.github/workflows/vaot-proposal.yaml
@@ -17,9 +17,7 @@ on:
 jobs:
   propose:
     runs-on: ubuntu-latest
-    if:
-      github.ref_name == 'main' || github.ref_name == 'develop' ||
-      github.event_name == 'workflow_dispatch'
+    if: github.ref_name == 'main' || github.ref_name == 'develop'
     environment: ${{ github.ref_name}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vaot-proposal.yaml
+++ b/.github/workflows/vaot-proposal.yaml
@@ -1,0 +1,116 @@
+name: VAOT Proposal
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+    inputs:
+      published_module_id:
+        required: true
+        type: string
+      published_lua_code_id:
+        required: false
+        type: string
+
+jobs:
+  propose:
+    runs-on: ubuntu-latest
+    if:
+      github.ref_name == 'main' || github.ref_name == 'develop' ||
+      github.event_name == 'workflow_dispatch'
+    environment: ${{ github.ref_name}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - run: yarn --frozen-lockfile
+      - run: yarn propose-version
+        env:
+          WALLET: ${{ secrets.WALLET }}
+          REGISTRY_ID: ${{ vars.REGISTRY_ID }}
+          VAOT_ID: ${{ vars.VAOT_ID}}
+          MODULE_ID: ${{ inputs.published_module_id }}
+          LUA_SOURCE_ID: ${{ inputs.published_lua_code_id }}
+      - name: Notify Success
+        if: success()
+        uses: rtCamp/action-slack-notify@v2.3.0
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: ANT Version Proposed to ANT Registry Process!
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CUSTOM_PAYLOAD: |
+            {
+              "attachments": [{
+                "fallback": "ANT Version Proposed for ANT Registry!",
+                "color": "good",
+                "title": "Details",
+                "text": 'The ANT Registry ${{ github.ref_name == 'main' && 'Testnet' || 'Devnet' }} Process has an ANT version update Proposal!',
+                "fields": [{
+                  "title": "Network",
+                  "value": "${{ github.ref_name == 'main' && 'testnet' || 'devnet' }}",
+                  "short": true
+                },
+                {
+                  "title": "Process ID",
+                  "value": "${{ vars.REGISTRY_ID }}",
+                  "short": true
+                },
+                {
+                  "title": "View on ao.link",
+                  "value": "https://www.ao.link/#/entity/${{ vars.REGISTRY_ID }}?tab=source-code",
+                  "short": false
+                },
+                 {
+                  "title": "Vote on this proposal in VAOT",
+                  "value": "https://vaot.ar.io/#/${{ vars.VAOT_ID }}",
+                  "short": false
+                },
+                {
+                  "title": "Commit",
+                  "value": "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+                }
+                ]
+              }]
+            }
+
+      - name: Notify Failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: danger
+          SLACK_TITLE: ANT Registry Process ANT version update Proposal FAILED!
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CUSTOM_PAYLOAD: |
+            {
+              "text": "ANT Registry Process ANT Version Proposal Failed!",
+              "attachments": [{
+                "fallback": "Failed to propose ANT version update to ANT Registry!",
+                "color": "danger",
+                "title": "Details",
+                "text": 'The ANT Registry ${{ github.ref_name == 'main' && 'Testnet' || 'Devnet' }} Process FAILED to create a version update Proposal!',
+                "fields": [{
+                  "title": "Network",
+                  "value": "${{ github.ref_name == 'main' && 'testnet' || 'devnet' }}",
+                  "short": true
+                },
+                {
+                  "title": "Process ID",
+                  "value": "${{ vars.REGISTRY_ID }}",
+                  "short": true
+                },
+                {
+                  "title": "GitHub Action",
+                  "value": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                  "short": false
+                },
+                {
+                  "title": "Commit",
+                  "value": "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+                }
+                ]
+              }]
+            }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "aos:spawn": "node tools/spawn-aos.mjs",
     "test": "yarn aos:build && node --test --test-concurrency 1 --experimental-wasm-memory64 **/*.test.mjs",
     "install-lua-deps": "sh tools/install-lua-deps.sh && luarocks install ar-io-ao-0.1-1.rockspec",
+    "propose-version": "node tools/propose-version.mjs",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/tools/propose-version.mjs
+++ b/tools/propose-version.mjs
@@ -1,0 +1,99 @@
+import path, { dirname } from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { ArweaveSigner } from '@ardrive/turbo-sdk';
+import { connect } from '@permaweb/aoconnect';
+import version from '../version.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/*
+example dryrun
+
+yarn propose-version \
+--dry-run \
+--ant-registry RR0vheYqtsKuJCWh6xj0beE35tjaEug5cejMw9n2aa8 \
+--vaot-id 4Ko7JmGPtbKLLqctNFr6ukWqX0lt4l0ktXgYKyMlbsM \
+--module pb4fCvdJqwT-_bn38ERMdqnOF4weRMjoJ6bY6yfl4a8 \
+--lua-source OO2ewZKq4AHoqGQmYUIl-NhJ-llQyFJ3ha4Uf4-w5RI
+
+*/
+
+function getLatestChanges() {
+  const content = fs.readFileSync(path.join(__dirname, '../CHANGELOG.md'), {
+    encoding: 'utf-8',
+  });
+
+  const match = content.match(/## \[\d+\].*?\n(.*?)(?=\n## \[\d+\])/s);
+
+  if (match && match[1]) {
+    // Trim and remove empty lines
+    return match[1].trim();
+  }
+}
+
+const dryRun =
+  process.argv.includes('--dry-run') || process.env.DRY_RUN === 'true';
+
+const registryId =
+  process.env.REGISTRY_ID ??
+  process.argv[process.argv.indexOf('--ant-registry') + 1];
+const vaotId =
+  process.env.VAOT_ID ?? process.argv[process.argv.indexOf('--vaot-id') + 1];
+const moduleId =
+  process.env.MODULE_ID ?? process.argv[process.argv.indexOf('--module') + 1];
+const luaSourceId =
+  process.env.LUA_SOURCE_ID ??
+  process.argv[process.argv.indexOf('--lua-source') + 1];
+
+const notes = getLatestChanges();
+
+const walletPath = process.argv.includes('--wallet-file')
+  ? process.argv[process.argv.indexOf('--wallet-file') + 1]
+  : process.env.WALLET_PATH || path.join(__dirname, 'key.json');
+
+const jwk = process.env.WALLET
+  ? JSON.parse(process.env.WALLET)
+  : JSON.parse(fs.readFileSync(walletPath, 'utf-8'));
+
+const signer = new ArweaveSigner(jwk);
+
+const ao = connect({
+  CU_URL: 'https://cu.ardrive.io',
+});
+
+if (dryRun) {
+  console.log({
+    vaotId,
+    version,
+    registryId,
+    moduleId,
+    luaSourceId,
+    notes,
+  });
+  process.exit('0');
+}
+
+const proposalResult = await ao.message({
+  process: vaotId,
+  tags: [
+    { name: 'Action', value: 'Propose' },
+    { name: 'Proposal-Type', value: 'Eval' },
+    { name: 'Vote', value: 'yay' },
+    { name: 'Process-Id', value: vaotId },
+  ],
+  data: `
+    Send({
+        Target = "${registryId}",
+        Version = "${version}",
+        ["Module-Id"] = "${moduleId}",
+        ${luaSourceId ? `["Lua-Source-Id"] = "${luaSourceId}",` : ''}
+        Notes = "${notes ?? ''}"
+    })
+  `,
+  signer,
+});
+if (!proposalResult || typeof proposalResult !== 'string')
+  throw new Error('Failed to create proposal');
+console.log(`Proposal result: ${JSON.stringify(proposalResult)}`);

--- a/tools/propose-version.mjs
+++ b/tools/propose-version.mjs
@@ -47,6 +47,20 @@ const luaSourceId =
   process.env.LUA_SOURCE_ID ??
   process.argv[process.argv.indexOf('--lua-source') + 1];
 
+// Validate required parameters
+if (!registryId) {
+  console.error("Missing required parameter: registry ID (--ant-registry or REGISTRY_ID)");
+  process.exit(1);
+}
+if (!vaotId) {
+  console.error("Missing required parameter: VAOT ID (--vaot-id or VAOT_ID)");
+  process.exit(1);
+}
+if (!moduleId) {
+  console.error("Missing required parameter: module ID (--module or MODULE_ID)");
+  process.exit(1);
+}
+
 const notes = getLatestChanges();
 
 const walletPath = process.argv.includes('--wallet-file')

--- a/tools/propose-version.mjs
+++ b/tools/propose-version.mjs
@@ -49,15 +49,19 @@ const luaSourceId =
 
 // Validate required parameters
 if (!registryId) {
-  console.error("Missing required parameter: registry ID (--ant-registry or REGISTRY_ID)");
+  console.error(
+    'Missing required parameter: registry ID (--ant-registry or REGISTRY_ID)',
+  );
   process.exit(1);
 }
 if (!vaotId) {
-  console.error("Missing required parameter: VAOT ID (--vaot-id or VAOT_ID)");
+  console.error('Missing required parameter: VAOT ID (--vaot-id or VAOT_ID)');
   process.exit(1);
 }
 if (!moduleId) {
-  console.error("Missing required parameter: module ID (--module or MODULE_ID)");
+  console.error(
+    'Missing required parameter: module ID (--module or MODULE_ID)',
+  );
   process.exit(1);
 }
 
@@ -77,15 +81,19 @@ const ao = connect({
   CU_URL: 'https://cu.ardrive.io',
 });
 
+const proposalEvalStr = `
+    Send({
+        Target = "${registryId}",
+        Version = "${version}",
+        ["Module-Id"] = "${moduleId}",
+        ${luaSourceId ? `["Lua-Source-Id"] = "${luaSourceId}",` : ''}
+        ${notes ? `Notes = "${notes}"` : ''}
+    })
+  `;
+
 if (dryRun) {
-  console.log({
-    vaotId,
-    version,
-    registryId,
-    moduleId,
-    luaSourceId,
-    notes,
-  });
+  console.log('Would have proposed to Eval: \n');
+  console.log(proposalEvalStr);
   process.exit('0');
 }
 
@@ -97,15 +105,7 @@ const proposalResult = await ao.message({
     { name: 'Vote', value: 'yay' },
     { name: 'Process-Id', value: vaotId },
   ],
-  data: `
-    Send({
-        Target = "${registryId}",
-        Version = "${version}",
-        ["Module-Id"] = "${moduleId}",
-        ${luaSourceId ? `["Lua-Source-Id"] = "${luaSourceId}",` : ''}
-        Notes = "${notes ?? ''}"
-    })
-  `,
+  data: proposalEvalStr,
   signer,
 });
 if (!proposalResult || typeof proposalResult !== 'string')

--- a/tools/propose-version.mjs
+++ b/tools/propose-version.mjs
@@ -8,6 +8,8 @@ import version from '../version.mjs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const TX_ID_REGEX = new RegExp('^[a-zA-Z0-9\\-_s+]{43}$');
+
 /*
 example dryrun
 
@@ -47,20 +49,20 @@ const luaSourceId =
   process.env.LUA_SOURCE_ID ??
   process.argv[process.argv.indexOf('--lua-source') + 1];
 
+const requiredIds = [registryId, vaotId, moduleId];
 // Validate required parameters
-if (!registryId) {
-  console.error(
-    'Missing required parameter: registry ID (--ant-registry or REGISTRY_ID)',
-  );
-  process.exit(1);
-}
-if (!vaotId) {
-  console.error('Missing required parameter: VAOT ID (--vaot-id or VAOT_ID)');
-  process.exit(1);
-}
-if (!moduleId) {
-  console.error(
-    'Missing required parameter: module ID (--module or MODULE_ID)',
+if (!requiredIds.every((id) => TX_ID_REGEX.test(id))) {
+  console.error('Missing required parameters!');
+  console.log(
+    JSON.stringify(
+      {
+        registryId,
+        moduleId,
+        vaotId,
+      },
+      null,
+      2,
+    ),
   );
   process.exit(1);
 }


### PR DESCRIPTION
Example dry run:

```bash
➜  ar-io-ant-process git:(PE-7650-propose-version-on-publish) ✗ yarn propose-version \
--dry-run \
--ant-registry RR0vheYqtsKuJCWh6xj0beE35tjaEug5cejMw9n2aa8 \
--vaot-id 4Ko7JmGPtbKLLqctNFr6ukWqX0lt4l0ktXgYKyMlbsM \
--module pb4fCvdJqwT-_bn38ERMdqnOF4weRMjoJ6bY6yfl4a8 \
--lua-source OO2ewZKq4AHoqGQmYUIl-NhJ-llQyFJ3ha4Uf4-w5RI
yarn run v1.22.22
$ node tools/propose-version.mjs --dry-run --ant-registry RR0vheYqtsKuJCWh6xj0beE35tjaEug5cejMw9n2aa8 --vaot-id 4Ko7JmGPtbKLLqctNFr6ukWqX0lt4l0ktXgYKyMlbsM --module pb4fCvdJqwT-_bn38ERMdqnOF4weRMjoJ6bY6yfl4a8 --lua-source OO2ewZKq4AHoqGQmYUIl-NhJ-llQyFJ3ha4Uf4-w5RI
{
  vaotId: '4Ko7JmGPtbKLLqctNFr6ukWqX0lt4l0ktXgYKyMlbsM',
  version: '16',
  registryId: 'RR0vheYqtsKuJCWh6xj0beE35tjaEug5cejMw9n2aa8',
  moduleId: 'pb4fCvdJqwT-_bn38ERMdqnOF4weRMjoJ6bY6yfl4a8',
  luaSourceId: 'OO2ewZKq4AHoqGQmYUIl-NhJ-llQyFJ3ha4Uf4-w5RI',
  notes: '## Changed\n' +
    '\n' +
    '- Increased stack memory and initial memory on modules to 3MiB and 4MiB\n' +
    '  respectively.'
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated version proposal process that triggers after successful releases.
  - Added integrated notifications to keep teams informed about proposal outcomes.
  - Launched a new command-line tool for managing version proposals, streamlining release and version tracking efforts.
  - New GitHub Actions workflow for version proposal management, enhancing automation.
  - Added a new script for proposing version updates in the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->