### PR TITLE
fix(PE-7817): ensure messages that are sent have valid tags

### DIFF
--- a/src/common/notices.lua
+++ b/src/common/notices.lua
@@ -42,13 +42,6 @@ function notices.debit(msg)
 	})
 end
 
---- @param noticesToSend table<AoMessage>
-function notices.sendNotices(noticesToSend)
-	for _, notice in ipairs(noticesToSend) do
-		utils.Send(msg, notice)
-	end
-end
-
 --- @param msg AoMessage
 --- @param target string
 --- @description Notify the target of the current state

--- a/src/common/notices.lua
+++ b/src/common/notices.lua
@@ -45,7 +45,7 @@ end
 --- @param noticesToSend table<AoMessage>
 function notices.sendNotices(noticesToSend)
 	for _, notice in ipairs(noticesToSend) do
-		ao.send(notice)
+		utils.Send(msg, notice)
 	end
 end
 

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -247,6 +247,41 @@ function utils.errorHandler(err)
 	return debug.traceback(err)
 end
 
+---@param outbox table
+---@description Validates the outbox
+---@example
+---```lua
+---utils.validateOutbox(ao.outbox)
+---```
+function utils.validateOutbox(outbox)
+	local messages = outbox.Messages
+	local spawns = outbox.Spawns
+	local assignments = outbox.Assignments
+
+	assert(type(messages) == "table" and type(spawns) == "table" and type(assignments) == "table")
+
+	for _, message in ipairs(messages) do
+		for _, tag in ipairs(message.Tags) do
+			local name, value = tag.name, tag.value
+			assert(type(name) == "string" and type(value) == "string", "Tag name and value must be strings")
+		end
+	end
+
+	for _, spawn in ipairs(spawns) do
+		for _, tag in ipairs(spawn.Tags) do
+			local name, value = tag.name, tag.value
+			assert(type(name) == "string" and type(value) == "string", "Tag name and value must be strings")
+		end
+	end
+
+	for _, assignment in ipairs(assignments) do
+		for _, tag in ipairs(assignment.Tags) do
+			local name, value = tag.name, tag.value
+			assert(type(name) == "string" and type(value) == "string", "Tag name and value must be strings")
+		end
+	end
+end
+
 ---@param tagName string
 ---@param tagValue string
 ---@param handler function
@@ -324,6 +359,15 @@ function utils.createHandler(tagName, tagValue, handler, position)
 				--luacheck: ignore
 				notices.notifyState(msg, AntRegistryId)
 			end
+
+			--[[
+			We specifically validate the outbox after the handler has been called, 
+			and all messages have been added to the outbox. 
+			This is to ensure that the outbox is valid before any notices are sent. 
+			We do not pcall this because we want to halt execution if the outbox is
+			invalid, so that any variables are not modified
+			]]
+			utils.validateOutbox(ao.outbox)
 
 			return handlerRes
 		end


### PR DESCRIPTION
## Outbox message guardrail 

AOS does not validate message structure when sending, so this adds some guards to ensure we handle that.

As it is, this will validate, messages, spawns, and assignments we send out, ensuring that if we create a malformed message, execution errors out.

That isnt a great UX however we need to error out to avoid the state being changed. This SHOULD ALWAYS BE CAUGHT IN TESTS - if things are well tested.

## Encoding tags

Object like (maps and arrays) will be encoded as json, numbers as strings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced validation checks to ensure that communication and task data adhere to the expected structure.
  - Streamlined data handling by directly constructing message fields without intermediate variables.
  - Updated the method for sending messages to utilize a new messaging function for consistency.

- **Bug Fixes**
  - Strengthened error handling to immediately stop processing when unexpected data is detected, improving overall system stability.
  
- **Chores**
  - Removed the bulk notice sending functionality from the notices module, impacting how notices are processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->