### PR TITLE
feat(ao): adds a patch state notice to any write interactions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,10 @@
 {
-  "[mjs, js]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "editor.formatOnPaste": true,
-    "editor.formatOnSaveMode": "file"
-  },
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "prettier.configPath": ".prettierrc",
   "prettier.prettierPath": "./node_modules/prettier/index.cjs",
-  "[typescript]": {
-    "editor.formatOnSave": true
-  },
-  "[markdown]": {
-    "editor.formatOnSave": true,
-    "editor.formatOnSaveMode": "file"
-  },
+  "javascript.format.enable": false,
+  "typescript.format.enable": false,
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "aos:publish": "node tools/bundle-aos.mjs && node tools/publish-aos.mjs",
     "aos:load": "node tools/bundle-aos.mjs && node tools/load-aos.mjs",
     "aos:spawn": "node tools/spawn-aos.mjs",
-    "test": "yarn aos:build && node --test --test-concurrency 1 --experimental-wasm-memory64 **/*.test.mjs",
+    "test": "yarn aos:build && node --test --experimental-wasm-memory64 **/*.test.mjs",
     "install-lua-deps": "sh tools/install-lua-deps.sh && luarocks install ar-io-ao-0.1-1.rockspec",
     "propose-version": "node tools/propose-version.mjs",
     "prepare": "husky"

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -352,7 +352,7 @@ function utils.createHandler(tagName, tagValue, handler, position)
 			-- note: did not add to notices to avoid circular dependency between notices and utils
 			ao.send({
 				device = "patch@1.0",
-				cache = json.encode(utils.getState()),
+				cache = { state = json.encode(utils.getState()) },
 			})
 
 			return handlerRes

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -348,6 +348,13 @@ function utils.createHandler(tagName, tagValue, handler, position)
 				notices.notifyState(msg, AntRegistryId)
 			end
 
+			-- send a patch notice on any action that changes the state
+			-- note: did not add to notices to avoid circular dependency between notices and utils
+			ao.send({
+				device = "patch@1.0",
+				cache = json.encode(utils.getState()),
+			})
+
 			return handlerRes
 		end
 	)

--- a/test/controllers.test.mjs
+++ b/test/controllers.test.mjs
@@ -1,4 +1,4 @@
-import { createAntAosLoader } from './utils.mjs';
+import { assertPatchMessage, createAntAosLoader } from './utils.mjs';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import {
@@ -84,6 +84,8 @@ describe('aos Controllers', async () => {
         ],
       });
 
+      assertPatchMessage(addControllerResult);
+
       const removeControllerResult = await handle(
         {
           Tags: [
@@ -93,6 +95,8 @@ describe('aos Controllers', async () => {
         },
         addControllerResult.Memory,
       );
+
+      assertPatchMessage(removeControllerResult);
 
       const controllersRes = await getControllers(
         removeControllerResult.Memory,

--- a/test/initialize.test.mjs
+++ b/test/initialize.test.mjs
@@ -1,4 +1,4 @@
-import { createAntAosLoader } from './utils.mjs';
+import { assertPatchMessage, createAntAosLoader } from './utils.mjs';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import {
@@ -61,5 +61,6 @@ describe('aos Initialization', async () => {
     assert.deepEqual(balances, antState.balances);
     assert.deepEqual(controllers, antState.controllers);
     assert.deepEqual(records, antState.records);
+    assertPatchMessage(result);
   });
 });

--- a/test/io.test.mjs
+++ b/test/io.test.mjs
@@ -31,8 +31,8 @@ describe('IO Network Updates', async () => {
       ],
     });
 
-    // two messages should be sent - one to the io process and one to the sender
-    assert(result.Messages?.length === 2, 'Expected two messages');
+    // three messages should be sent - one to the io process, one to the sender, and one to the patch
+    assert(result.Messages?.length === 3, 'Expected three messages');
 
     // Check if there is a message to the IO Process ID with Action 'Release-Name'
     const ioProcessMessage = result.Messages.find(
@@ -74,8 +74,8 @@ describe('IO Network Updates', async () => {
       Owner: 'not-owner',
     });
 
-    // assert no other messages
-    assert(result.Messages?.length === 1, 'Expected only one message');
+    // assert 2 messages, including the patch message for hyperbeam
+    assert(result.Messages?.length === 2, 'Expected two messages');
 
     const error = result.Messages[0]?.Tags.find(
       (tag) => tag.name === 'Error' && tag.value === 'Release-Name-Error',
@@ -93,8 +93,8 @@ describe('IO Network Updates', async () => {
       ],
     });
 
-    // two messages should be sent - one to the io process and one to the sender
-    assert(result.Messages?.length === 2, 'Expected two messages');
+    // two messages should be sent - one to the io process and one to the sender, and one to the patch
+    assert(result.Messages?.length === 3, 'Expected three messages');
 
     // Check if there is a message to the IO Process ID with Action 'Reassign-Name'
     const ioProcessMessage = result.Messages.find(
@@ -148,8 +148,8 @@ describe('IO Network Updates', async () => {
       Owner: 'not-owner',
     });
 
-    // assert no other messages
-    assert(result.Messages?.length === 1, 'Expected only one message');
+    // assert 2 messages, including the patch message for hyperbeam
+    assert(result.Messages?.length === 2, 'Expected two messages');
 
     const error = result.Messages[0]?.Tags.find(
       (tag) => tag.name === 'Error' && tag.value === 'Reassign-Name-Error',
@@ -167,8 +167,8 @@ describe('IO Network Updates', async () => {
       ],
     });
 
-    // assert no other messages
-    assert(result.Messages?.length === 1, 'Expected only one message');
+    // assert 2 messages, including the patch message for hyperbeam
+    assert(result.Messages?.length === 2, 'Expected two messages');
 
     const error = result.Messages[0]?.Tags.find(
       (tag) => tag.name === 'Error' && tag.value === 'Reassign-Name-Error',

--- a/test/records.test.mjs
+++ b/test/records.test.mjs
@@ -1,4 +1,4 @@
-import { createAntAosLoader } from './utils.mjs';
+import { assertPatchMessage, createAntAosLoader } from './utils.mjs';
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import {
@@ -82,6 +82,7 @@ describe('aos Records', async () => {
     assert(record);
     assert(record.transactionId);
     assert(record.ttlSeconds);
+    assertPatchMessage(result);
   });
 
   it('should set the record of an ANT', async () => {
@@ -105,6 +106,7 @@ describe('aos Records', async () => {
     const record = records['@'];
     assert(record.transactionId === ''.padEnd(43, '3'));
     assert(record.ttlSeconds === 900);
+    assertPatchMessage(result);
   });
 
   it('should remove the record of an ANT', async () => {
@@ -136,6 +138,7 @@ describe('aos Records', async () => {
 
     const record = JSON.parse(recordsResult.Messages[0].Data)['timmy'];
     assert(!record);
+    assertPatchMessage(result);
   });
 
   it('should set name as lower case when provided as uppercase', async () => {
@@ -159,6 +162,7 @@ describe('aos Records', async () => {
     const record = records['timmy'];
     assert(record.transactionId === ''.padEnd(43, '3'));
     assert(record.ttlSeconds === 900);
+    assertPatchMessage(result);
   });
 
   it('should set name with priority order', async () => {
@@ -184,6 +188,7 @@ describe('aos Records', async () => {
     assert(record.transactionId === ''.padEnd(43, '3'));
     assert(record.ttlSeconds === 900);
     assert(record.priority === 1);
+    assertPatchMessage(result);
   });
 
   it('should force priority to 0 for @ record', async () => {
@@ -207,6 +212,7 @@ describe('aos Records', async () => {
 
     const record = records['@'];
     assert(record.priority === 0);
+    assertPatchMessage(result);
   });
 
   it('should fail when setting priority for @ record', async () => {
@@ -229,5 +235,6 @@ describe('aos Records', async () => {
     const records = JSON.parse(recordsResult.Messages[0].Data);
 
     assert(!records['timmy']);
+    assertPatchMessage(result);
   });
 });

--- a/test/records.test.mjs
+++ b/test/records.test.mjs
@@ -82,7 +82,6 @@ describe('aos Records', async () => {
     assert(record);
     assert(record.transactionId);
     assert(record.ttlSeconds);
-    assertPatchMessage(result);
   });
 
   it('should set the record of an ANT', async () => {
@@ -95,6 +94,8 @@ describe('aos Records', async () => {
       ],
     });
 
+    assertPatchMessage(setRecordResult);
+
     const recordsResult = await handle(
       {
         Tags: [{ name: 'Action', value: 'Records' }],
@@ -106,7 +107,6 @@ describe('aos Records', async () => {
     const record = records['@'];
     assert(record.transactionId === ''.padEnd(43, '3'));
     assert(record.ttlSeconds === 900);
-    assertPatchMessage(result);
   });
 
   it('should remove the record of an ANT', async () => {
@@ -119,6 +119,8 @@ describe('aos Records', async () => {
       ],
     });
 
+    assertPatchMessage(setRecordResult);
+
     const removeRecordResult = await handle(
       {
         Tags: [
@@ -129,6 +131,8 @@ describe('aos Records', async () => {
       setRecordResult.Memory,
     );
 
+    assertPatchMessage(removeRecordResult);
+
     const recordsResult = await handle(
       {
         Tags: [{ name: 'Action', value: 'Records' }],
@@ -138,7 +142,6 @@ describe('aos Records', async () => {
 
     const record = JSON.parse(recordsResult.Messages[0].Data)['timmy'];
     assert(!record);
-    assertPatchMessage(result);
   });
 
   it('should set name as lower case when provided as uppercase', async () => {
@@ -151,6 +154,8 @@ describe('aos Records', async () => {
       ],
     });
 
+    assertPatchMessage(setRecordResult);
+
     const recordsResult = await handle(
       {
         Tags: [{ name: 'Action', value: 'Records' }],
@@ -162,7 +167,6 @@ describe('aos Records', async () => {
     const record = records['timmy'];
     assert(record.transactionId === ''.padEnd(43, '3'));
     assert(record.ttlSeconds === 900);
-    assertPatchMessage(result);
   });
 
   it('should set name with priority order', async () => {
@@ -176,6 +180,8 @@ describe('aos Records', async () => {
       ],
     });
 
+    assertPatchMessage(setRecordResult);
+
     const recordsResult = await handle(
       {
         Tags: [{ name: 'Action', value: 'Records' }],
@@ -188,11 +194,10 @@ describe('aos Records', async () => {
     assert(record.transactionId === ''.padEnd(43, '3'));
     assert(record.ttlSeconds === 900);
     assert(record.priority === 1);
-    assertPatchMessage(result);
   });
 
   it('should force priority to 0 for @ record', async () => {
-    const res = await handle({
+    const setRecordResult = await handle({
       Tags: [
         { name: 'Action', value: 'Set-Record' },
         { name: 'Sub-Domain', value: '@' },
@@ -202,21 +207,22 @@ describe('aos Records', async () => {
       ],
     });
 
+    assertPatchMessage(setRecordResult);
+
     const recordsResult = await handle(
       {
         Tags: [{ name: 'Action', value: 'Records' }],
       },
-      res.Memory,
+      setRecordResult.Memory,
     );
     const records = JSON.parse(recordsResult.Messages[0].Data);
 
     const record = records['@'];
     assert(record.priority === 0);
-    assertPatchMessage(result);
   });
 
   it('should fail when setting priority for @ record', async () => {
-    const res = await handle({
+    const setRecordResult = await handle({
       Tags: [
         { name: 'Action', value: 'Set-Record' },
         { name: 'Sub-Domain', value: 'timmy' },
@@ -226,15 +232,17 @@ describe('aos Records', async () => {
       ],
     });
 
+    assertPatchMessage(setRecordResult);
+
     const recordsResult = await handle(
       {
         Tags: [{ name: 'Action', value: 'Records' }],
       },
-      res.Memory,
+      setRecordResult.Memory,
     );
     const records = JSON.parse(recordsResult.Messages[0].Data);
 
     assert(!records['timmy']);
-    assertPatchMessage(result);
+    assertPatchMessage(recordsResult);
   });
 });

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -5,6 +5,7 @@ import {
   DEFAULT_HANDLE_OPTIONS,
   AOS_ANT_WASM,
 } from '../tools/constants.mjs';
+import assert from 'node:assert';
 
 export async function createAntAosLoader(wasmModule = AOS_ANT_WASM) {
   const handle = await AoLoader(wasmModule, AO_LOADER_OPTIONS);
@@ -43,4 +44,29 @@ export function createHandleWrapper(
       aoLoaderHandlerEnv,
     );
   };
+}
+
+/**
+ * Asserts that the result has a patch message and that the cache tag is present.
+ *
+ * These messages are used by HyperBeam nodes to provide cached state of ANTs. They are sent after all other messages and right now, include the full `getState()`.
+ * @param {*} result
+ */
+export function assertPatchMessage(result) {
+  assert(result.Messages?.length > 1, 'Expected more than one message');
+  // patch should be the last message
+  const patchMessage = result.Messages[result.Messages.length - 1];
+  assert(
+    patchMessage.Tags.some(
+      (tag) => tag.name === 'device' && tag.value === 'patch@1.0',
+    ),
+    'Expected patch message on state change',
+  );
+  // should include the cache tag with the object with state as the value
+  assert(
+    patchMessage.Tags.some(
+      (tag) => tag.name === 'cache' && tag.value.state !== undefined,
+      'Expected cache tag in patch message',
+    ),
+  );
 }

--- a/tools/spawn-aos.mjs
+++ b/tools/spawn-aos.mjs
@@ -2,6 +2,10 @@ import { connect, createDataItemSigner } from '@permaweb/aoconnect';
 import fs from 'fs';
 import path from 'path';
 import Arweave from 'arweave';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const arweave = Arweave.init({
   host: 'arweave.net',
@@ -14,14 +18,17 @@ const ao = connect({
 });
 const moduleId = 'cbn0KKrBZH7hdNkNokuXLtGryrWM--PjSTBqIzw9Kkk';
 const scheduler = '_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA';
-
+const walletFile =
+  process.argv.indexOf('--wallet') !== -1 &&
+  process.argv[process.argv.indexOf('--wallet') + 1]
+    ? process.argv[process.argv.indexOf('--wallet') + 1]
+    : 'key.json';
 async function main() {
   const luaCode = fs.readFileSync(
     path.join(__dirname, '../dist/aos-bundled.lua'),
     'utf-8',
   );
-
-  const wallet = fs.readFileSync(path.join(__dirname, 'key.json'), 'utf-8');
+  const wallet = fs.readFileSync(walletFile, 'utf-8');
   const address = await arweave.wallets.jwkToAddress(JSON.parse(wallet));
   const signer = createDataItemSigner(JSON.parse(wallet));
 
@@ -55,7 +62,6 @@ async function main() {
   const testCases = [
     ['Eval', {}, luaCode],
     ['Initialize-State', {}, initState],
-    ['Transfer', { Recipient: 'N4h8M9A9hasa3tF47qQyNvcKjm4APBKuFs7vqUVm-SI' }],
   ];
 
   for (const [method, args, data] of testCases) {


### PR DESCRIPTION
I considered putting this on specific handlers, but ANT state is likely small enough where this should be fine for most use cases. We can test and validate if we want to provide notices only on the state diff per handler, if necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The system now sends a patch notice with the latest state snapshot after any action that changes the state. This occurs automatically and independently of other notifications.
- **Tests**
  - Enhanced test coverage by validating patch messages across multiple scenarios.
  - Updated message count expectations in network IO tests to include the new patch message.
- **Chores**
  - Simplified editor formatting settings for a consistent development experience.
  - Improved script flexibility by allowing configurable wallet file paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->