### PR TITLE
fix(ant): send `Patch-State` messages to a ANT cache process, instead…

### DIFF
--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -24,7 +24,6 @@ function ant.init()
 	---@alias Controllers table<integer, string>
 	---@description The list of controllers for the ANT
 	Controllers = Controllers or { Owner }
-
 	---@alias Name string
 	---@description The name of the ANT
 	Name = Name or "Arweave Name Token"
@@ -52,6 +51,9 @@ function ant.init()
 	---@alias AntRegistryId string
 	---@description The Arweave ID of the ANT Registry contract that this ANT is registered with
 	AntRegistryId = AntRegistryId or ao.env.Process.Tags["ANT-Registry-Id"] or nil
+	---@alias AntCacheRegistryId string
+	---@description The Arweave ID of the ANT Cache Registry contract that this ANT is registered with
+	AntCacheRegistryId = AntCacheRegistryId or ao.env.Process.Tags["ANT-Cache-Registry-Id"] or nil
 
 	local ActionMap = {
 		-- write

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -348,12 +348,14 @@ function utils.createHandler(tagName, tagValue, handler, position)
 				notices.notifyState(msg, AntRegistryId)
 			end
 
-			-- send a patch notice on any action that changes the state
-			-- note: did not add to notices to avoid circular dependency between notices and utils
-			ao.send({
-				device = "patch@1.0",
-				cache = utils.getState(), -- serialization is done by hyperbeam ~seralize@1.0 device, so no need to spend compute here to do it
-			})
+			-- send a patch state to the ANT Cache Process, we do this to avoid cranking issues for legacy MUs that cannot parse patch notices with raw lua data
+			if AntCacheRegistryId then
+				ao.send({
+					Target = AntCacheRegistryId,
+					Action = "Patch-State",
+					Data = utils.getState(),
+				})
+			end
 
 			return handlerRes
 		end


### PR DESCRIPTION
… of to self

The `patch` messages do not get cranked by legacy MUs. They are strictly for hyperbeam to read cached state, so instead we will send to a centralized ANT registry process which will hold the cached state and allow us to read from.

Related - https://github.com/ar-io/ar-io-ant-registry-process/pull/31/files