### PR TITLE
fix(boot): add patch message for _boot handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [20] - (2025-6-12)
+
+### Changed
+
+- Updated ANT state initialization to send a patch notice on boot.
+
 ## [19] - (2025-5-19)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated ANT state initialization to send a patch notice on boot.
 
-## [19] - (2025-5-19)
+## [19] - (2025-6-10)
 
 ### Added
 

--- a/src/common/main.lua
+++ b/src/common/main.lua
@@ -386,6 +386,12 @@ function ant.init()
 		if AntRegistryId then
 			notices.notifyState(msg, AntRegistryId)
 		end
+
+		-- send a patch notice on instance boot
+		ao.send({
+			device = "patch@1.0",
+			cache = utils.getState(), -- serialization is done by hyperbeam ~seralize@1.0 device, so no need to spend compute here to do it
+		})
 	end, 1)
 end
 

--- a/version.mjs
+++ b/version.mjs
@@ -1,3 +1,3 @@
 // TODO: make this an auto generated file
 
-export default '19';
+export default '20';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- On startup, the system now sends a patch notice with the current state to an external device.
- **Documentation**
	- Added a changelog entry for version 20 with details about the update.
- **Chores**
	- Updated the application version to 20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->