### PR TITLE
fix(primary names): fix undername parsing issues

### DIFF
--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -298,12 +298,54 @@ describe("undernameForName", function()
 		local name = undername .. "_" .. basename
 
 		local undernameFromName = utils.undernameForName(name)
-		assert.are.same(undernameFromName, undername)
+		assert.are.same(undername, undernameFromName)
 	end)
 
 	it("should return nil for a name with no undername", function()
 		local basename = "basename"
 		local undernameFromName = utils.undernameForName(basename)
-		assert.are.same(undernameFromName, nil)
+		assert.are.same(nil, undernameFromName)
+	end)
+
+	it("should get the undername name for a name with an undername and base name with dashes", function()
+		local undername = "test"
+		local basename = "base-name-with-dashes"
+		local name = undername .. "_" .. basename
+
+		local undernameFromName = utils.undernameForName(name)
+		assert.are.same(undername, undernameFromName)
+	end)
+
+	it("should return nil for a base name with dashes but no undername", function()
+		local basename = "base-name-with-dashes"
+		local undernameFromName = utils.undernameForName(basename)
+		assert.are.same(nil, undernameFromName)
+	end)
+
+	it("should handle complex undername with base name containing dashes", function()
+		local undername = "my-complex-undername"
+		local basename = "test-base-name-with-dashes"
+		local name = undername .. "_" .. basename
+
+		local undernameFromName = utils.undernameForName(name)
+		assert.are.same(undername, undernameFromName)
+	end)
+
+	it("should handle case where undername and base name are identical", function()
+		local undername = "samename"
+		local basename = "samename"
+		local name = undername .. "_" .. basename
+
+		local undernameFromName = utils.undernameForName(name)
+		assert.are.same(undername, undernameFromName)
+	end)
+
+	it("should handle case where undername and base name are identical with dashes", function()
+		local undername = "same-name-with-dashes"
+		local basename = "same-name-with-dashes"
+		local name = undername .. "_" .. basename
+
+		local undernameFromName = utils.undernameForName(name)
+		assert.are.same(undername, undernameFromName)
 	end)
 end)

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -450,7 +450,9 @@ function utils.undernameForName(name)
 	end
 
 	local baseName = utils.baseNameForName(name)
-	return string.gsub(name:reverse(), baseName:reverse() .. "_", "", 1):reverse()
+	-- Escape the pattern to treat it as literal text, not a pattern
+	local pattern = string.gsub(baseName:reverse() .. "_", "([%-%.%+%[%]%(%)%$%^%%%?%*])", "%%%1")
+	return string.gsub(name:reverse(), pattern, "", 1):reverse()
 end
 
 return utils

--- a/src/common/utils.lua
+++ b/src/common/utils.lua
@@ -445,14 +445,13 @@ end
 --- @param name string An ArNS name with or without an undername
 --- @return string|nil # The undername, if present, or nil
 function utils.undernameForName(name)
-	if not name:match("_") then
+	local reversedName = name:reverse()
+
+	local startIndex = reversedName:find("_", nil, true)
+	if not startIndex then
 		return nil
 	end
-
-	local baseName = utils.baseNameForName(name)
-	-- Escape the pattern to treat it as literal text, not a pattern
-	local pattern = string.gsub(baseName:reverse() .. "_", "([%-%.%+%[%]%(%)%$%^%%%?%*])", "%%%1")
-	return string.gsub(name:reverse(), pattern, "", 1):reverse()
+	return reversedName:sub(startIndex + 1):reverse()
 end
 
 return utils

--- a/test/primary_names.test.mjs
+++ b/test/primary_names.test.mjs
@@ -135,4 +135,74 @@ describe('Primary Names', async () => {
     assert.strictEqual(actionTag.value, 'Invalid-Remove-Primary-Names-Notice');
     assertPatchMessage(res);
   });
+
+  it('should allow undername owners to approve primary names for themselves', async () => {
+    const primaryNames = [
+      'test_alice',
+      'test_bob',
+      'test_charlie',
+      'test_undername',
+      'test_undername-with-base-dashes',
+      'test-undername_with-base-dashes',
+      'test-mirror_test-mirror',
+      'test_multiple_underscores_boop-test',
+      'test_1234',
+      '1234_test',
+    ];
+    const ioProcessId = ''.padEnd(43, '5');
+
+    // Test each primary name with an undername owner
+    for (const [index, primaryName] of primaryNames.entries()) {
+      const recordOwner = `record-owner-${index}-`.padEnd(43, '7');
+      const undername = primaryName.split('_').slice(0, -1).join('_');
+
+      // First, create a record with the undername owner
+      const createRecordRes = await handle({
+        Tags: [
+          { name: 'Action', value: 'Set-Record' },
+          { name: 'Sub-Domain', value: undername },
+          { name: 'Transaction-Id', value: STUB_RECIPIENT },
+          { name: 'TTL-Seconds', value: '900' },
+          { name: 'Record-Owner', value: recordOwner },
+        ],
+      });
+
+      assertPatchMessage(createRecordRes);
+
+      // Now the record owner approves the primary name for themselves
+      const approveRes = await handle(
+        {
+          From: recordOwner,
+          Owner: recordOwner,
+          Tags: [
+            { name: 'Action', value: 'Approve-Primary-Name' },
+            { name: 'Name', value: primaryName },
+            { name: 'Recipient', value: recordOwner },
+            { name: 'IO-Process-Id', value: ioProcessId },
+          ],
+        },
+        createRecordRes.Memory,
+      );
+
+      // Assert that approval was sent
+      const approvalMessage = approveRes.Messages.find(
+        (m) =>
+          m.Target === ioProcessId &&
+          m.Tags.find(
+            (t) =>
+              t.name === 'Action' && t.value === 'Approve-Primary-Name-Request',
+          ),
+      );
+
+      assert(approvalMessage, `Should send approval for ${primaryName}`);
+      assert.strictEqual(
+        approvalMessage.Tags.find((t) => t.name === 'Name').value,
+        primaryName,
+      );
+      assert.strictEqual(
+        approvalMessage.Tags.find((t) => t.name === 'Recipient').value,
+        recordOwner,
+      );
+    }
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved name parsing to correctly extract undernames when names contain dashes or complex segments, avoiding false matches and returning nil when appropriate.

- **Tests**
  - Added unit and integration tests covering dash-containing and edge-case name formats.
  - Added a scenario verifying undername owners can approve primary names for themselves.
  - Fixed several test assertions for accurate expected/actual ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->